### PR TITLE
Changed the server config to serve the whole folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG APT_CATCHER_IP=localhost
 # if you do not want to use caching
 RUN  echo 'Acquire::http { Proxy "http://'${APT_CATCHER_IP}':3142"; };' >> /etc/apt/apt.conf.d/01proxy
 
-ARG VERSION="-1.0-RC3"
+ARG VERSION="1.0-RC3"
 
 #-------------Application Specific Stuff ----------------------------------------------------
 RUN apt-get -y update

--- a/setup.sh
+++ b/setup.sh
@@ -10,8 +10,8 @@ then
         unzip geogig-dev-latest.zip
         rm geogig-dev-latest.zip
     else
-        wget https://github.com/locationtech/geogig/releases/download/${VERSION}/geogig${VERSION}.zip
-        unzip ${VERSION}.zip
+        wget https://github.com/locationtech/geogig/releases/download/${VERSION}/geogig-${VERSION}.zip
+        unzip geogig-${VERSION}.zip
         mv GeoGig-${VERSION} /geogig
         rm ${VERSION}.zip
     fi
@@ -22,7 +22,8 @@ mkdir -p  /etc/service
 mkdir -p  /etc/service/geogig_serve
 cd /etc/service/geogig_serve
 echo "#!/bin/bash
-exec /geogig/bin/geogig serve /geogig_repo" > run
+# Serve all repos under the specified folder
+exec /geogig/bin/geogig serve -m /geogig_repo" > run
 chmod 0755 run
 
 GEOGIG_PATH=/geogig/bin
@@ -31,10 +32,10 @@ echo "export PATH=${GEOGIG_PATH}:$PATH" >>/root/.bashrc
 # Make an empty repo
 export PATH=/geogig/bin:$PATH
 cd /
-if [ ! -d /geogig_repo ]
+if [ ! -d /geogig_repo/test_repo ]
 then
-    mkdir geogig_repo
+    mkdir -p geogig_repo/test_repo
 fi
 
-cd geogig_repo
+cd geogig_repo/test_repo
 /geogig/bin/geogig init


### PR DESCRIPTION
This fixes an issue with the correct URL for versions download.
I've also moved the sample repo to a subfolder and we are now serving all repos from the parent folder.
