### PR TITLE
Update GeoGig bundle links and remove BerkeleyDB plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,6 @@ RUN  echo 'Acquire::http { Proxy "http://'${APT_CATCHER_IP}':3142"; };' >> /etc/
 
 ARG VERSION="1.1.1"
 
-# leave empty to use default plugins or set to "BDB" to install also Berkley DB dev plugin
-ARG BDBPLUGIN=""
-
 # leave empty to use default plugins or set to "OSM" to install also OSM dev plugin
 ARG OSMPLUGIN=""
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ cd docker-geogig
 ```
 **VERSION** build arg can be set to `dev` for the lastest
 development build or to a specific version, the default
-value is `1.0-RC3` and it will build geogig-`1.0-RC3`.
-
-**BDBPLUGIN** build arg to be set to BDB to install Berkley DB dev geogig plugin
+value is `1.1.1` and it will build geogig-`1.1.1`.
 
 **OSMPLUGIN** build arg to be set to OSM to install OSM dev geogig plugin
 
+**BDBPLUGIN no longer supported** As of GeoGig release 1.0, the BerkeleyDB backend has been replaced by RocksDB
+(https://github.com/facebook/rocksdb)
 
 ```bash
 # Set $ADDR to your APT_CATCHER_IP

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@
 if [ ! -d /geogig ]
 then
     if [ "${VERSION}" = "dev" ]; then
-        wget http://ares.boundlessgeo.com/geogig/master/geogig-master-latest.zip
+        wget http://build-slave-01.geoserver.org/geogig/master/geogig-master-latest.zip
         unzip geogig-master-latest.zip
         rm geogig-master-latest.zip
     else
@@ -19,16 +19,17 @@ fi
 # install plugins
 if [ -d /geogig/lib ]
 then
-    if [ "${BDBPLUGIN}" = "BDB" ]; then
-        wget http://ares.boundlessgeo.com/geogig/dev/geogig-plugins-bdbje-dev-latest.zip
-        unzip -j -d /geogig/lib geogig-plugins-bdbje-dev-latest.zip
-        rm geogig-plugins-bdbje-dev-latest.zip
-    fi
-
     if [ "${OSMPLUGIN}" = "OSM" ]; then
-        wget http://ares.boundlessgeo.com/geogig/dev/geogig-plugins-osm-dev-latest.zip
-        unzip -j -d /geogig/lib geogig-plugins-osm-dev-latest.zip
-        rm geogig-plugins-osm-dev-latest.zip
+        # make sure the OSM plugin version matches the GeoGig version
+        if [ "${VERSION}" = "dev" ]; then
+            wget http://build-slave-01.geoserver.org/geogig/master/geogig-plugins-osm-master-latest.zip
+            unzip -j -d /geogig/lib geogig-plugins-osm-master-latest.zip
+            rm geogig-plugins-osm-master-latest.zip
+        else
+            wget https://github.com/locationtech/geogig/releases/download/v${VERSION}/geogig-plugins-osm-${VERSION}.zip
+            unzip -j -d /geogig/lib geogig-plugins-osm-${VERSION}.zip
+            rm geogig-plugins-osm-${VERSION}.zip
+        fi
     fi
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -16,18 +16,25 @@ then
     fi
 fi
 
+# set the GeoGig plugin/lib directory based on version. For GeoGig 1.1.x it is "lib", for 1.2.x/dev it is "libexec".
+if [ "${VERSION}" = "dev" ]; then
+    GEOGIG_PLUGIN_DIR=/geogig/libexec
+else
+    GEOGIG_PLUGIN_DIR=/geogig/lib
+fi
+
 # install plugins
-if [ -d /geogig/lib ]
+if [ -d ${GEOGIG_PLUGIN_DIR} ]
 then
     if [ "${OSMPLUGIN}" = "OSM" ]; then
         # make sure the OSM plugin version matches the GeoGig version
         if [ "${VERSION}" = "dev" ]; then
             wget http://build-slave-01.geoserver.org/geogig/master/geogig-plugins-osm-master-latest.zip
-            unzip -j -d /geogig/lib geogig-plugins-osm-master-latest.zip
+            unzip -j -d ${GEOGIG_PLUGIN_DIR} geogig-plugins-osm-master-latest.zip
             rm geogig-plugins-osm-master-latest.zip
         else
             wget https://github.com/locationtech/geogig/releases/download/v${VERSION}/geogig-plugins-osm-${VERSION}.zip
-            unzip -j -d /geogig/lib geogig-plugins-osm-${VERSION}.zip
+            unzip -j -d ${GEOGIG_PLUGIN_DIR} geogig-plugins-osm-${VERSION}.zip
             rm geogig-plugins-osm-${VERSION}.zip
         fi
     fi


### PR DESCRIPTION
  The links to GeoGig bundles are stale as the build jobs have
  moved to a new server. Also, since the 1.0 release of GeoGig,
  the BerkeleyDB plugin has been mostly abandoned. It has been
  replaced by RocksDB, which is included in the GeoGig bundle.

Signed-off-by: Erik Merkle <emerkle@boundlessgeo.com>